### PR TITLE
Created resources that enable access to Amazon ElastiCache 

### DIFF
--- a/iam_role.tf
+++ b/iam_role.tf
@@ -1,0 +1,22 @@
+#Create a policy to read from the specific parameter store
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy
+resource "aws_iam_policy" "ssm_parameter_policy" {
+  name        = "ssm_parameter_policy"
+  path        = "/"
+  description = "Policy to read from SSM Parameter Store"
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ssm:GetParameters",
+          "ssm:GetParameter"
+        ],
+        Resource = [aws_ssm_parameter.elasticache_ep.arn, aws_ssm_parameter.elasticache_port.arn]
+      }
+    ]
+  })
+}

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -1,0 +1,11 @@
+https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
+resource "aws_ssm_parameter" "elasticache_ep" {
+  name  = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
+  type  = "String"
+  value = aws_elasticache_replication_group.app4.configuration_endpoint_address
+}
+resource "aws_ssm_parameter" "elasticache_port" {
+  name  = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/port"
+  type  = "String"
+  value = aws_elasticache_replication_group.app4.port
+}

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -1,4 +1,4 @@
-https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
 resource "aws_ssm_parameter" "elasticache_ep" {
   name  = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
   type  = "String"

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -1,11 +1,13 @@
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
 resource "aws_ssm_parameter" "elasticache_ep" {
-  name  = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
-  type  = "String"
-  value = aws_elasticache_replication_group.app4.configuration_endpoint_address
+  name   = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
+  type   = "SecureString"
+  key_id = aws_kms_key.encrytion_rest.id
+  value  = aws_elasticache_replication_group.app4.configuration_endpoint_address
 }
 resource "aws_ssm_parameter" "elasticache_port" {
-  name  = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/port"
-  type  = "String"
-  value = aws_elasticache_replication_group.app4.port
+  name   = "/elasticache/${aws_elasticache_replication_group.app4.replication_group_id}/port"
+  type   = "SecureString"
+  key_id = aws_kms_key.encrytion_rest.id
+  value  = aws_elasticache_replication_group.app4.port
 }


### PR DESCRIPTION
This PR closes #18 and closes #17. The resources created enable other services to access the ElastiCache endpoints by reading them from the SSM Parameter Store