### PR TITLE
Updated Amazon ElastiCache for Redis cluster `auth_token` generation

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -104,7 +104,6 @@ jobs:
       if: github.ref != 'refs/heads/main' || github.event_name == 'pull_request'
       run: |
         terraform plan -no-color -input=false \
-        -var="elasticache_auth=${{ secrets.elasticache_auth }}" \
         -out=TFplan.JSON
       continue-on-error: true
 
@@ -161,5 +160,4 @@ jobs:
     - name: Terraform Apply
       if: github.ref == 'refs/heads/main'
       run: |
-        terraform apply -auto-approve -input=false \
-        -var="elasticache_auth=${{ secrets.elasticache_auth }}"
+        terraform apply -auto-approve -input=false

--- a/elasticache.tf
+++ b/elasticache.tf
@@ -22,7 +22,7 @@ resource "aws_secretsmanager_secret" "elasticache_auth" {
 }
 resource "aws_secretsmanager_secret_version" "auth" {
   secret_id     = aws_secretsmanager_secret.elasticache_auth.id
-  secret_string = var.elasticache_auth
+  secret_string = random_password.auth.result
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group
 resource "aws_elasticache_replication_group" "app4" {

--- a/provider.tf
+++ b/provider.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.20.1"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "3.5.1"
+    }
   }
 }
 
@@ -16,4 +20,7 @@ provider "aws" {
       Source = "https://github.com/kunduso/add-asg-elb-terraform"
     }
   }
+}
+provider "random" {
+  # Configuration options
 }

--- a/provider.tf
+++ b/provider.tf
@@ -5,7 +5,7 @@ terraform {
       version = "5.20.1"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "3.5.1"
     }
   }

--- a/random.tf
+++ b/random.tf
@@ -1,0 +1,6 @@
+#https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html#auth-overview
+resource "random_password" "auth" {
+  length           = 90
+  special          = true
+  override_special = "!&#$^<>-"
+}

--- a/variable.tf
+++ b/variable.tf
@@ -32,8 +32,3 @@ variable "subnet_cidr_public" {
   default     = ["10.20.32.96/27"]
   type        = list(any)
 }
-variable "elasticache_auth" {
-  description = "The auth token to the Amazon ElastiCache cluster. This value is passed to Terraform from the pipeline."
-  type        = string
-  sensitive   = true
-}


### PR DESCRIPTION
Instead of storing the `auth_token` as a GitHub Actions secret, this PR is creating a Random resource and updating the AWS Secrets Manager secret with the new value. This PR closes #24 