### PR TITLE
Corrected AWS KMS Key policy to attach the AWS CloudWatch log group

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,10 +1,10 @@
 resource "aws_cloudwatch_log_group" "slow_log" {
   name              = "/elasticache/${var.replication_group_id}/slow-log"
   retention_in_days = 365
-  kms_key_id        = aws_kms_key.encrytion_rest.id
+  kms_key_id        = aws_kms_key.encryption_rest.arn
 }
 resource "aws_cloudwatch_log_group" "engine_log" {
   name              = "/elasticache/${var.replication_group_id}/engine-log"
   retention_in_days = 365
-  kms_key_id        = aws_kms_key.encrytion_rest.id
+  kms_key_id        = aws_kms_key.encryption_rest.arn
 }

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,7 @@
+data "aws_caller_identity" "current" {}
+locals {
+  principal_root_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+  principal_logs_arn = "logs.${var.region}.amazonaws.com"
+  slow_log_arn = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.replication_group_id}/slow-log"
+  engine_log_arn = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.replication_group_id}/engine-log"
+}

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 locals {
-  principal_root_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+  principal_root_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
   principal_logs_arn = "logs.${var.region}.amazonaws.com"
-  slow_log_arn = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.replication_group_id}/slow-log"
-  engine_log_arn = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.replication_group_id}/engine-log"
+  slow_log_arn       = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.replication_group_id}/slow-log"
+  engine_log_arn     = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.replication_group_id}/engine-log"
 }

--- a/elasticache.tf
+++ b/elasticache.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_subnet_group" "elasticache_subnet" {
 resource "aws_secretsmanager_secret" "elasticache_auth" {
   name                    = "app-4-elasticache-auth"
   recovery_window_in_days = 0
-  kms_key_id              = aws_kms_key.encryption_rest.id
+  kms_key_id              = aws_kms_key.encryption_secret.id
   #checkov:skip=CKV2_AWS_57: Disabled Secrets Manager secrets automatic rotation
 }
 resource "aws_secretsmanager_secret_version" "auth" {

--- a/elasticache.tf
+++ b/elasticache.tf
@@ -2,28 +2,18 @@ resource "aws_elasticache_subnet_group" "elasticache_subnet" {
   name       = "app-4-cache-subnet"
   subnet_ids = [for subnet in aws_subnet.private : subnet.id]
 }
-resource "aws_kms_key" "encrytion_rest" {
-  enable_key_rotation     = true
-  description             = "Key to encrypt cache at rest"
-  deletion_window_in_days = 7
-  #checkov:skip=CKV2_AWS_64: Not including a KMS Key policy
-}
-resource "aws_kms_key" "encrytion_secret" {
-  enable_key_rotation     = true
-  description             = "Key to encrypt secret"
-  deletion_window_in_days = 7
-  #checkov:skip=CKV2_AWS_64: Not including a KMS Key policy
-}
+
 resource "aws_secretsmanager_secret" "elasticache_auth" {
   name                    = "app-4-elasticache-auth"
   recovery_window_in_days = 0
-  kms_key_id              = aws_kms_key.encrytion_secret.id
+  kms_key_id              = aws_kms_key.encryption_rest.id
   #checkov:skip=CKV2_AWS_57: Disabled Secrets Manager secrets automatic rotation
 }
 resource "aws_secretsmanager_secret_version" "auth" {
   secret_id     = aws_secretsmanager_secret.elasticache_auth.id
   secret_string = random_password.auth.result
 }
+
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group
 resource "aws_elasticache_replication_group" "app4" {
   automatic_failover_enabled = true
@@ -37,7 +27,7 @@ resource "aws_elasticache_replication_group" "app4" {
   num_node_groups            = 3
   replicas_per_node_group    = 2
   at_rest_encryption_enabled = true
-  kms_key_id                 = aws_kms_key.encrytion_rest.id
+  kms_key_id                 = aws_kms_key.encryption_rest.id
   transit_encryption_enabled = true
   auth_token                 = aws_secretsmanager_secret_version.auth.secret_string
   security_group_ids         = [aws_security_group.elasticache.id]

--- a/iam_role.tf
+++ b/iam_role.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "ssm_parameter_policy" {
         Action = [
           "kms:Decrypt"
         ]
-        Resource = [aws_kms_key.encrytion_rest.arn]
+        Resource = [aws_kms_key.encryption_rest.arn]
       }
     ]
   })
@@ -42,14 +42,14 @@ resource "aws_iam_policy" "secret_manager_policy" {
         Action = [
           "secretsmanager:GetSecretValue"
         ]
-        Resource = [aws_secretsmanager_secret_version.auth.arn]
+        Resource = []
       },
       {
         Effect = "Allow",
         Action = [
           "kms:Decrypt"
         ]
-        Resource = [aws_kms_key.encrytion_secret.arn]
+        Resource = [aws_kms_key.encryption_secret.arn]
       }
     ]
   })

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,58 @@
+
+resource "aws_kms_key" "encrytion_secret" {
+  enable_key_rotation     = true
+  description             = "Key to encrypt secret"
+  deletion_window_in_days = 7
+  #checkov:skip=CKV2_AWS_64: Not including a KMS Key policy
+}
+resource "aws_kms_alias" "encrytion_secret" {
+  name          = "alias/elasticache-app-4-in-transit"
+  target_key_id = aws_kms_key.encrytion_secret.key_id
+}
+resource "aws_kms_key" "encryption_rest" {
+  enable_key_rotation     = true
+  description             = "Key to encrypt cache at rest."
+  deletion_window_in_days = 7
+  #checkov:skip=CKV2_AWS_64: Not including a KMS Key policy
+}
+resource "aws_kms_alias" "encryption_rest" {
+  name          = "alias/elasticache-app-4-at-rest"
+  target_key_id = aws_kms_key.encryption_rest.key_id
+}
+resource "aws_kms_key_policy" "encryption_rest_policy" {
+  key_id = aws_kms_key.encryption_rest.id
+  policy = jsonencode({
+    Id = "encryption-rest"
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "${local.principal_root_arn}"
+        }
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Effect : "Allow",
+        Principal : {
+          Service : "${local.principal_logs_arn}"
+        },
+        Action : [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ],
+        Resource : "*",
+        Condition : {
+          ArnEquals : {
+            "kms:EncryptionContext:aws:logs:arn" : [local.slow_log_arn, local.engine_log_arn]
+          }
+        }
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}

--- a/kms.tf
+++ b/kms.tf
@@ -13,7 +13,7 @@ resource "aws_kms_key" "encryption_rest" {
   enable_key_rotation     = true
   description             = "Key to encrypt cache at rest."
   deletion_window_in_days = 7
-  #checkov:skip=CKV2_AWS_64: Not including a KMS Key policy
+  #checkov:skip=CKV2_AWS_64: KMS Key policy in a separate resource
 }
 resource "aws_kms_alias" "encryption_rest" {
   name          = "alias/elasticache-app-4-at-rest"

--- a/kms.tf
+++ b/kms.tf
@@ -1,13 +1,13 @@
 
-resource "aws_kms_key" "encrytion_secret" {
+resource "aws_kms_key" "encryption_secret" {
   enable_key_rotation     = true
   description             = "Key to encrypt secret"
   deletion_window_in_days = 7
   #checkov:skip=CKV2_AWS_64: Not including a KMS Key policy
 }
-resource "aws_kms_alias" "encrytion_secret" {
+resource "aws_kms_alias" "encryption_secret" {
   name          = "alias/elasticache-app-4-in-transit"
-  target_key_id = aws_kms_key.encrytion_secret.key_id
+  target_key_id = aws_kms_key.encryption_secret.key_id
 }
 resource "aws_kms_key" "encryption_rest" {
   enable_key_rotation     = true

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -2,12 +2,12 @@
 resource "aws_ssm_parameter" "elasticache_ep" {
   name = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
   type = "SecureString"
-  #key_id = aws_kms_key.encryption_rest.id
+  key_id = aws_kms_key.encryption_rest.id
   value = aws_elasticache_replication_group.app4.configuration_endpoint_address
 }
 resource "aws_ssm_parameter" "elasticache_port" {
   name = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/port"
   type = "SecureString"
-  #key_id = aws_kms_key.encryption_rest.id
+  key_id = aws_kms_key.encryption_rest.id
   value = aws_elasticache_replication_group.app4.port
 }

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -2,12 +2,12 @@
 resource "aws_ssm_parameter" "elasticache_ep" {
   name   = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
   type   = "SecureString"
-  key_id = aws_kms_key.encrytion_rest.id
+  #key_id = aws_kms_key.encryption_rest.id
   value  = aws_elasticache_replication_group.app4.configuration_endpoint_address
 }
 resource "aws_ssm_parameter" "elasticache_port" {
   name   = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/port"
   type   = "SecureString"
-  key_id = aws_kms_key.encrytion_rest.id
+  #key_id = aws_kms_key.encryption_rest.id
   value  = aws_elasticache_replication_group.app4.port
 }

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -1,13 +1,13 @@
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
 resource "aws_ssm_parameter" "elasticache_ep" {
-  name   = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
-  type   = "SecureString"
+  name = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
+  type = "SecureString"
   #key_id = aws_kms_key.encryption_rest.id
-  value  = aws_elasticache_replication_group.app4.configuration_endpoint_address
+  value = aws_elasticache_replication_group.app4.configuration_endpoint_address
 }
 resource "aws_ssm_parameter" "elasticache_port" {
-  name   = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/port"
-  type   = "SecureString"
+  name = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/port"
+  type = "SecureString"
   #key_id = aws_kms_key.encryption_rest.id
-  value  = aws_elasticache_replication_group.app4.port
+  value = aws_elasticache_replication_group.app4.port
 }

--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -1,13 +1,13 @@
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
 resource "aws_ssm_parameter" "elasticache_ep" {
-  name = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
-  type = "SecureString"
+  name   = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/endpoint"
+  type   = "SecureString"
   key_id = aws_kms_key.encryption_rest.id
-  value = aws_elasticache_replication_group.app4.configuration_endpoint_address
+  value  = aws_elasticache_replication_group.app4.configuration_endpoint_address
 }
 resource "aws_ssm_parameter" "elasticache_port" {
-  name = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/port"
-  type = "SecureString"
+  name   = "/elasticache/app-4/${aws_elasticache_replication_group.app4.replication_group_id}/port"
+  type   = "SecureString"
   key_id = aws_kms_key.encryption_rest.id
-  value = aws_elasticache_replication_group.app4.port
+  value  = aws_elasticache_replication_group.app4.port
 }


### PR DESCRIPTION
The changes in this PR closes #32 and #30 
These are the changes:
-correct the KMS key attached to the AWS CloudWatch log group logs
-attach a KMS key policy to the KMS key
-correct the KMS key names
